### PR TITLE
Fixed exception syntax

### DIFF
--- a/permission/permission.py
+++ b/permission/permission.py
@@ -32,7 +32,7 @@ class Permission(object):
         if not self.check():
             try:
                 self.deny()
-            except Exception, e:
+            except Exception as e:
                 raise e
             else:
                 raise PermissionDeniedException()


### PR DESCRIPTION
The `except Exc, e` syntax was deprecated and doesn't work in Python 3.x
